### PR TITLE
Remove FUNDING.yml in favor of org-level configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: xemantic


### PR DESCRIPTION
## Summary
- Removes the per-repository `.github/FUNDING.yml` file
- The funding configuration is now maintained centrally in `xemantic/.github/FUNDING.yml`
- This avoids duplication and makes it easier to update funding links across all repositories

🤖 Generated with [Claude Code](https://claude.com/claude-code)